### PR TITLE
Correct module information for extensions module

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -1,3 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use xcb::x::{ConfigWindow, ConfigWindowMask, ConfigureRequestEvent};
 
 /// Extends [ConfigWindow], allowing easy access to a field's [ConfigWindowMask].

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,10 +6,7 @@
 // ICCCM    https://tronche.com/gui/x/icccm/
 // EWMH     https://specifications.freedesktop.org/wm-spec/latest/
 
-/// Provides various helpful wrappers that make interacting with [xcb] easier.
-///
-/// Items in this module simply wrap existing items within [xcb], providing utilities that
-/// streamline communication with the X server.
+/// Useful trait extensions for [xcb] to provide easier access to certain utilities.
 pub mod extensions;
 
 /// Handles events from the event loop.


### PR DESCRIPTION
Replaced outdated description of extensions module with an accurate description, and added the proper license header to the extensions module file.